### PR TITLE
Raise Windows CI blame-hang-timeout to 60s

### DIFF
--- a/.github/workflows/dotnet-ci-windows.yml
+++ b/.github/workflows/dotnet-ci-windows.yml
@@ -71,4 +71,4 @@ jobs:
         run: dotnet build --no-restore ${{ inputs.solution-file }}
 
       - name: Test
-        run: dotnet test --no-build --verbosity normal --blame-hang-timeout 20s --blame-crash ${{ inputs.solution-file }}
+        run: dotnet test --no-build --verbosity normal --blame-hang-timeout 60s --blame-crash ${{ inputs.solution-file }}


### PR DESCRIPTION
Aligns the Windows CI test timeout with Linux to remove a recurring flaky failure.

## Problem

The two reusable CI workflows use different test timeouts:

- **Linux** (`dotnet-ci.yml`) runs `dotnet ci --check`, which invokes `dotnet test` with `--blame-hang-timeout 60s`.
- **Windows** (`dotnet-ci-windows.yml`) ran `dotnet test` directly with `--blame-hang-timeout 20s`.

On a loaded Windows runner, a test that occasionally takes longer than 20 seconds — such as the heavier Roslyn analyzer tests — trips the blame hang collector, which writes a dump and force-kills the test host. The run then fails with "Test host process crashed" even though nothing is actually broken (it passes on re-run). Linux tolerates the same test because it allows 60s.

## Change

`dotnet-ci-windows.yml`: `--blame-hang-timeout 20s` → `60s`, matching the Linux path.

## Impact

Fixes the flaky Windows aborts for every consumer repo that uses this reusable workflow, not just one. This is mitigation aligned with the existing approach (the `dotnet ci` path already settled on 60s); a genuine deadlock would still trip at 60s, which is the correct behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI/CD pipeline timeout settings to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->